### PR TITLE
Fix crashes and errors if missing data

### DIFF
--- a/liveportrait/utils/cropper.py
+++ b/liveportrait/utils/cropper.py
@@ -52,7 +52,7 @@ class CropperInsightFace(object):
             direction=direction
         )
 
-        if len(src_face) == 0:
+        if len(src_face) == 0 or face_index >= len(src_face):
             ret_dct = {}
             cropped_image_256 = None
             return ret_dct, cropped_image_256


### PR DESCRIPTION
Fix crashes `'NoneType' object is not subscriptable` and `IndexError: list index out of range` happening when:
- `FaceShaperCropper` gets a `face_index` value that is not in range
- `FaceShaperComposite` gets input from a `FaceShaperCropper` that just failed to find an appropriate face (for out of range `face_index` for example).

This makes the node much more reliable when doing automated tasks, and will simply skip frames where the number of faces is not that expected (due to angles or similar).